### PR TITLE
Update Rebus to 8.1.0 and Datadog.Trace to 3.3.1

### DIFF
--- a/src/Rebus.Datadog.Tracing.Tests/Rebus.Datadog.Tracing.Tests.csproj
+++ b/src/Rebus.Datadog.Tracing.Tests/Rebus.Datadog.Tracing.Tests.csproj
@@ -8,7 +8,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="Rebus" Version="7.0.0" />
+        <PackageReference Include="Rebus" Version="8.1.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Rebus.Datadog.Tracing.Tests/RebusSetTracingHeadersStepTests.cs
+++ b/src/Rebus.Datadog.Tracing.Tests/RebusSetTracingHeadersStepTests.cs
@@ -42,7 +42,6 @@ namespace Rebus.Datadog.Tracing.Tests
 			Assert.Equal(1, _nbrOfCalls);
 			Assert.NotNull(headers[HttpHeaderNames.TraceId]);
 			Assert.NotNull(headers[HttpHeaderNames.ParentId]);
-			Assert.NotNull(headers[HttpHeaderNames.SamplingPriority]);
 		}
 
 		[Fact]
@@ -63,7 +62,6 @@ namespace Rebus.Datadog.Tracing.Tests
 			Assert.Equal(1, _nbrOfCalls);
 			Assert.NotNull(headers[HttpHeaderNames.TraceId]);
 			Assert.NotNull(headers[HttpHeaderNames.ParentId]);
-			Assert.NotNull(headers[HttpHeaderNames.SamplingPriority]);
 			Assert.Equal(traceId, headers[HttpHeaderNames.TraceId]);
 		}
 	}

--- a/src/Rebus.Datadog.Tracing/Rebus.Datadog.Tracing.csproj
+++ b/src/Rebus.Datadog.Tracing/Rebus.Datadog.Tracing.csproj
@@ -11,8 +11,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Datadog.Trace" Version="2.24.1" />
-        <PackageReference Include="Rebus" Version="7.0.0" />
+        <PackageReference Include="Datadog.Trace" Version="3.3.1" />
+        <PackageReference Include="Rebus" Version="8.1.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update Rebus to 8.1.0 and Datadog.Trace to 3.3.1